### PR TITLE
Video.css no longer exists so Bower install breaks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "video.js",
   "version": "4.2.2",
-  "main": ["video.js", "video.css"]
+  "main": ["video.js", "video-js.css"]
 }


### PR DESCRIPTION
Just updated the bower.json file so it works with the new css file name.
